### PR TITLE
removes more false positives for unused-argument

### DIFF
--- a/tests/input/unused-argument/func_param_as_fixture_arg.py
+++ b/tests/input/unused-argument/func_param_as_fixture_arg.py
@@ -1,0 +1,24 @@
+"""
+This module illustrates a situation in which unused-argument should be
+suppressed, but is not.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def myfix(arg):
+    """A fixture that requests a function param"""
+    print("arg is ", arg)
+    return True
+
+
+@pytest.mark.parametrize("arg", [1, 2, 3])
+def test_myfix(myfix, arg):
+    """A test function that uses the param through a fixture"""
+    assert myfix
+
+@pytest.mark.parametrize("narg", [4, 5, 6])
+def test_nyfix(narg):  # unused-argument
+    """A test function that does not use its param"""
+    assert True

--- a/tests/test_unused_argument.py
+++ b/tests/test_unused_argument.py
@@ -28,3 +28,8 @@ class TestUnusedArgument(BasePytestTester):
     def test_args_and_kwargs(self, enable_plugin):
         self.run_linter(enable_plugin)
         self.verify_messages(2)
+
+    @pytest.mark.parametrize('enable_plugin', [True, False])
+    def test_func_param_as_fixture_arg(self, enable_plugin):
+        self.run_linter(enable_plugin)
+        self.verify_messages(1 if enable_plugin else 2)


### PR DESCRIPTION
Previously unhandled: cases where a test function and at least one fixture share an argument. Pytest will pass the test's argument value to the fixture.